### PR TITLE
added: new functionality to be able to create a drag-handle

### DIFF
--- a/dragster.js
+++ b/dragster.js
@@ -481,7 +481,7 @@
              */
             mousedown: function (event) {
                 if (finalParams.dragHandleCssClass &&
-                    (typeof finalParams.dragHandleCssClass === 'string' ||
+                    (typeof finalParams.dragHandleCssClass !== 'string' ||
                     !event.target.classList.contains(finalParams.dragHandleCssClass))) {
                     return false;
                 }

--- a/dragster.js
+++ b/dragster.js
@@ -41,6 +41,7 @@
             finalParams = {
                 elementSelector: '.dragster-block',
                 regionSelector: '.dragster-region',
+                dragHandleCssClass: FALSE,
                 dragOnlyRegionCssClass: CLASS_DRAG_ONLY,
                 replaceElements: FALSE,
                 updateRegionsHeight: TRUE,
@@ -479,6 +480,12 @@
              * @param event {Object} event object
              */
             mousedown: function (event) {
+                if (finalParams.dragHandleCssClass &&
+                    (typeof finalParams.dragHandleCssClass === 'string' ||
+                    !event.target.classList.contains(finalParams.dragHandleCssClass))) {
+                    return false;
+                }
+
                 var targetRegion,
                     listenToEventName;
 


### PR DESCRIPTION
Just a really simple addition, so a drag handle can be created. Only when the mouse down event happend on this `element` the dragging will fire.