### PR TITLE
Shadow element stays under mouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,14 @@ The drag-only region CSS class name. Used to identify regions. Default value: `'
 ### cloneElements - {Boolean}
 The flag stating the elements can be cloned from region to region. Requires `dragOnlyRegionCssClass` to be applied in the HTML markup of a page. Default value: `false`.
 ### wrapDraggableElements - {Boolean}
-By default all draggable elements are wrapped in a wrapper `<div>`, by settings this variable to `false` this behavior can be disabled. This can sometimes be useful when using the script in frameworks like Angular or such. 
+By default all draggable elements are wrapped in a wrapper `<div>`, by settings this variable to `false` this behavior can be disabled. This can sometimes be useful when using the script in frameworks like Angular or such.
 
 **IMPORTANT**
 
-If you put this value to `false`, you **MUST** do the wrapping of the elements yourself. 
+If you put this value to `false`, you **MUST** do the wrapping of the elements yourself.
 A wrapper container looks like this `<div draggable="true" class="dragster-draggable"> ... </div>`
+### shadowElementUnderMouse - {Boolean}
+By default the shadow element is placed on half of its width, by setting this variable to `true` the shadow element will stays where user clicks on draggable element.
 
 ## Properties - callbacks
 These properties allow a developer to control the behaviour of dragster.js library using callbacks.

--- a/dragster.js
+++ b/dragster.js
@@ -58,6 +58,7 @@
                 dragOnlyRegionsEnabled: FALSE,
                 cloneElements: FALSE,
                 wrapDraggableElements: TRUE,
+                shadowElementUnderMouse: FALSE,
             },
             placeholderAttrName = 'data-placeholder-position',
             visiblePlaceholder = {
@@ -174,6 +175,8 @@
             discoverWindowHeight,
             dropActions,
             moveActions,
+            shadowElementPositionXDiff,
+            shadowElementPositionYDiff,
             windowHeight = window.innerHeight;
 
         // merge the object with default config with an object with params provided by a developer
@@ -486,7 +489,8 @@
                 }
 
                 var targetRegion,
-                    listenToEventName;
+                    listenToEventName,
+                    eventObject = event.changedTouches ? event.changedTouches[0] : event;
 
                 event.dragster = dragsterEventInfo;
 
@@ -511,6 +515,10 @@
                 }
 
                 targetRegion = draggedElement.getBoundingClientRect();
+
+                shadowElementPositionXDiff = targetRegion.left - eventObject.clientX;
+                shadowElementPositionYDiff = targetRegion.top - eventObject.clientY;
+
                 shadowElement = createShadowElement();
                 shadowElement.innerHTML = draggedElement.innerHTML;
                 shadowElement.style.width = targetRegion.width + UNIT;
@@ -555,8 +563,10 @@
                     elementPositionX = eventObject.clientX + pageXOffset,
                     unknownTarget = document.elementFromPoint(eventObject.clientX, eventObject.clientY),
                     dropTarget = getElement(unknownTarget, isDraggableCallback),
-                    top = eventObject.clientY,
-                    left = elementPositionX - (shadowElementRegion.width / 2),
+                    top = finalParams.shadowElementUnderMouse ? eventObject.clientY + shadowElementPositionYDiff : eventObject.clientY,
+                    left = finalParams.shadowElementUnderMouse ?
+                        elementPositionX + shadowElementPositionXDiff :
+                        elementPositionX - (shadowElementRegion.width / 2),
                     isInDragOnlyRegion = !!(dropTarget && getElement(dropTarget, isInDragOnlyRegionCallback)),
                     isTargetRegion = unknownTarget.classList.contains(CLASS_REGION),
                     isTargetRegionDragOnly = unknownTarget.classList.contains(CLASS_DRAG_ONLY),


### PR DESCRIPTION
The goal here is to add configuration for enable shadow element to stay under mouse where user clicks on draggable element not move to half of the width.