### PR TITLE
fixed replaceElements : old  behaviour broke complex elements and their event listeners

### DIFF
--- a/dragster.es6.js
+++ b/dragster.es6.js
@@ -859,11 +859,27 @@ var Dragster = function (params) {
         replaceElements: function (dragsterEvent, dropDraggableTarget) {
             var dropTemp = document.getElementsByClassName(CLASS_TEMP_CONTAINER)[0];
 
-            dropTemp.innerHTML = draggedElement.innerHTML;
+            var obj1= draggedElement;
+            var obj2 = dropDraggableTarget;
+            var parent2 = obj2.parentNode;
+            var next2 = obj2.nextSibling;
+            // special case for obj1 is the next sibling of obj2
+            if (next2 === obj1) {
+                // just put obj1 before obj2
+                parent2.insertBefore(obj1, obj2);
+            } else {
+                // insert obj2 right before obj1
+                obj1.parentNode.insertBefore(obj2, obj1);
 
-            draggedElement.innerHTML = dropDraggableTarget.innerHTML;
-            dropDraggableTarget.innerHTML = dropTemp.innerHTML;
-            dropTemp.innerHTML = '';
+                // now insert obj1 where obj2 was
+                if (next2) {
+                    // if there was an element after obj2, then insert obj1 right before that
+                    parent2.insertBefore(obj1, next2);
+                } else {
+                    // otherwise, just append as last child
+                    parent2.appendChild(obj1);
+                }
+            }
             dragsterEvent.dropped = dropTemp;
 
             return dragsterEvent;

--- a/dragster.js
+++ b/dragster.js
@@ -872,11 +872,28 @@ var Dragster = function (params) {
         replaceElements: function (dragsterEvent, dropDraggableTarget) {
             var dropTemp = document.getElementsByClassName(CLASS_TEMP_CONTAINER)[0];
 
-            dropTemp.innerHTML = draggedElement.innerHTML;
+            var obj1= draggedElement;
+            var obj2 = dropDraggableTarget;
+            var parent2 = obj2.parentNode;
+            var next2 = obj2.nextSibling;
+            // special case for obj1 is the next sibling of obj2
+            if (next2 === obj1) {
+                // just put obj1 before obj2
+                parent2.insertBefore(obj1, obj2);
+            } else {
+                // insert obj2 right before obj1
+                obj1.parentNode.insertBefore(obj2, obj1);
 
-            draggedElement.innerHTML = dropDraggableTarget.innerHTML;
-            dropDraggableTarget.innerHTML = dropTemp.innerHTML;
-            dropTemp.innerHTML = '';
+                // now insert obj1 where obj2 was
+                if (next2) {
+                    // if there was an element after obj2, then insert obj1 right before that
+                    parent2.insertBefore(obj1, next2);
+                } else {
+                    // otherwise, just append as last child
+                    parent2.appendChild(obj1);
+                }
+            }
+            
             dragsterEvent.dropped = dropTemp;
 
             return dragsterEvent;


### PR DESCRIPTION
Like I said in the title, the current behaviour of the replaceElements function can break complex elements and their event listeners, because it **copy-pastes** html code instead of **moving** the elements.